### PR TITLE
fix/allow declaring variables inside a switch statement

### DIFF
--- a/test/features/controlflow/switch.feature
+++ b/test/features/controlflow/switch.feature
@@ -61,18 +61,24 @@ Example: Local variables can be used inside cases
         var b = 2;
         switch (a){
             case 1: {
-                var c = 3; // 'c' gets assigned call frame offset that contains copy of condition 
-                var d = 4; // 'd' gets assigned call frame offset that contains '3' 
-                print c;   
+                // The switch condition is kept on the stack.
+                // Verify that it does not interfere with local vars.
+                var c = 3; 
+                var d = 4; 
+                print c;    
                 print d;   
             }
         }
+        // Verify switch condition has been forgotten.
+        var e = 5;
+        print e; 
     }
     ```
     Then clox prints to stdout:
     ```
-    1
     3
+    4
+    5
     ```
 
 Example: Semantic error: Zero 'case'es and no 'default' branch

--- a/test/features/controlflow/switch.feature
+++ b/test/features/controlflow/switch.feature
@@ -53,6 +53,28 @@ Example: The 'default' branch is executed when there are zero 'case'es
     "x"
     ```        
 
+Example: Local variables can be used inside cases
+    When running a clox file:
+    ```
+    {   // make all vars locals
+        var a = 1;
+        var b = 2;
+        switch (a){
+            case 1: {
+                var c = 3; // 'c' gets assigned call frame offset that contains copy of condition 
+                var d = 4; // 'd' gets assigned call frame offset that contains '3' 
+                print c;   
+                print d;   
+            }
+        }
+    }
+    ```
+    Then clox prints to stdout:
+    ```
+    1
+    3
+    ```
+
 Example: Semantic error: Zero 'case'es and no 'default' branch
     When running a clox file:
     ```


### PR DESCRIPTION
## Bug

This code:
```
{
    var a = 1;
    switch (a){
        case 1: {
            var b = 2;
            print b;
        }
    }
}
```

Would output:
```
1
```

## Cause

The condition of the `switch` is evaluated, and for each `case` a copy of the value is created so that this value remains available for the next `case` (because `OP_EQUAL` used to evaluate the case eats the value).

This extra value on the stack threw off book keeping of local variables.

## Fix

Declare the condition value as an anonymous local variable. Users cannot access these variables because they have no name, but the compiler can refer to them using their offset.